### PR TITLE
Fix bad "precise32-vcenter.box" URL in example "Vagrantfile"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Configuration
 Here's a sample Multi-VM Vagrantfile:
 
 ```ruby
-precise32_box_url = 'http://vagrant.tsugliani.fr/precise32-vcenter.box'
+precise32_box_url = 'http://vagrant.gosddc.com/boxes/precise32-vcenter.box'
 
 nodes = [
   { hostname: 'web-vm',


### PR DESCRIPTION
The existing URL returns a 404.  The new URL is a 200.
