### PR TITLE
Installing the 'vagrant-vcenter' plugin. error

### DIFF
--- a/vagrant-vcenter.gemspec
+++ b/vagrant-vcenter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'vagrant-rbvmomi', '~> 1.8.1'
   s.add_runtime_dependency 'log4r', '~> 1.1.10'
-  s.add_runtime_dependency 'nokogiri', '1.5.5'
+  s.add_runtime_dependency 'nokogiri', '~> 1.5.5'
   s.add_runtime_dependency 'pry'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Installing the 'vagrant-vcenter' plugin. This can take a few minutes...
The plugin(s) can't be installed due to the version conflicts below.
This means that the plugins depend on a library version that conflicts
with other plugins or Vagrant itself, creating an impossible situation
where Vagrant wouldn't be able to load the plugins.

You can fix the issue by either removing a conflicting plugin or
by contacting a plugin author to see if they can address the conflict.

Vagrant could not find compatible versions for gem "nokogiri":
  In Gemfile:
    vagrant-vcenter (>= 0) ruby depends on
      nokogiri (= 1.5.5) ruby

```
vagrant (= 1.6.5) ruby depends on
  nokogiri (1.6.3.1)
```
