### PR TITLE
Add new VM state when vCenter api call cannot find the VM

### DIFF
--- a/lib/vagrant-vcenter/action/read_state.rb
+++ b/lib/vagrant-vcenter/action/read_state.rb
@@ -35,7 +35,11 @@ module VagrantPlugins
           # @logger.debug("Current power state: #{vm.runtime.powerState}")
           vm_name = env[:machine].name
 
-          if vm.runtime.powerState == 'poweredOff'
+          if vm.nil?
+            # If the VM has been cloned/moved, the findByUuid call returns nil
+            @logger.info("VM [#{vm_name}] state is unknown")
+            return :unknown
+          elsif vm.runtime.powerState == 'poweredOff'
             @logger.info("VM [#{vm_name}] is stopped")
             return :stopped
           elsif vm.runtime.powerState == 'poweredOn'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -50,3 +50,6 @@ en:
         shut it down forcefully, or you can run `vagrant suspend` to simply
         suspend the virtual machine. In either case, to restart it again,
         simply run `vagrant up`.
+      unknown: |-
+        The VM state cannot be retrieved from vCenter. Please contact your
+        vCenter administrator for more informations.


### PR DESCRIPTION
Hi,

It's probably coming from problems in the way the VM were managed in vcenter but I ran into this problem after a few months of use of the plugin:

```
$ vagrant status
C:/Users/mpereira/.vagrant.d/gems/gems/vagrant-vcenter-0.3.2/lib/vagrant-vcenter/action/read_state.rb:38:in `read_state': undefined method `runtime' for nil:NilClass (NoMethodError)
        from C:/Users/mpereira/.vagrant.d/gems/gems/vagrant-vcenter-0.3.2/lib/vagrant-vcenter/action/read_state.rb:14:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from C:/Users/mpereira/.vagrant.d/gems/gems/vagrant-vcenter-0.3.2/lib/vagrant-vcenter/action/connect_vcenter.rb:32:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/warden.rb:34:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/builder.rb:116:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `block in run'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/util/busy.rb:19:in `busy'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/action/runner.rb:66:in `run'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:224:in `action_raw'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:199:in `block in action'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/environment.rb:561:in `lock'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:185:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:185:in `action'
        from C:/Users/mpereira/.vagrant.d/gems/gems/vagrant-vcenter-0.3.2/lib/vagrant-vcenter/provider.rb:28:in `state'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:501:in `state'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/machine.rb:144:in `initialize'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/vagrantfile.rb:79:in `new'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/vagrantfile.rb:79:in `machine'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/environment.rb:663:in `machine'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/plugin/v2/command.rb:177:in `block in with_target_vms'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/plugin/v2/command.rb:210:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/plugin/v2/command.rb:210:in `block in with_target_vms'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/plugin/v2/command.rb:209:in `map'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/plugin/v2/command.rb:209:in `with_target_vms'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/plugins/commands/status/command.rb:20:in `execute'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/cli.rb:42:in `execute'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/lib/vagrant/environment.rb:302:in `cli'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.8.1/bin/vagrant:174:in `<main>'

```

The problem comes from this call in `lib/vagrant-vcenter/action/read_state.rb`:
```
vm = root_vm_folder.findByUuid(env[:machine].id)`
```
which might return `nil` if the machine id cannot be found and makes the rest of the code fail.

With the attached fix, the vm state is displayed as unknown, which allows the `vagrant status` call to display the rest of the information without issues.


```
$ vagrant status
Current machine states:

oracle12-svr1             running (vcenter)
oracle12-svr2             running (vcenter)
oracle12-svr3             running (vcenter)
oracle12-svr4             running (vcenter)
oracle12-svr5             running (vcenter)
oracle12-svr6             running (vcenter)
oracle12-svr7             unknown (vcenter)
```
I also added a small detailed error message, feel free to propose a better one if you find this one inadequate.
```
$ vagrant status oracle12-svr7
Current machine states:

oracle12-svr7             unknown (vcenter)

The VM state cannot be retrieved from vCenter. Please contact your
vCenter administrator for more informations.
```

Best regards
